### PR TITLE
Stop printing spec errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Stop printing spec errors (#2, fixes #1)
+
 ## 0.2.0
 
 ### Added

--- a/src/climate/error.ml
+++ b/src/climate/error.ml
@@ -180,6 +180,5 @@ module Spec_error = struct
 end
 
 let spec_error error =
-  Printf.eprintf "%s" (Spec_error.to_string error);
   raise (Spec_error.E error)
 ;;

--- a/tests/unit_tests/spec_error_tests.ml
+++ b/tests/unit_tests/spec_error_tests.ml
@@ -6,7 +6,7 @@ let check f =
     let _ = Command.singleton (f ()) in
     ()
   with
-  | Spec_error.E _ -> ()
+  | Spec_error.E e -> Printf.eprintf "%s" (Spec_error.to_string e)
 ;;
 
 let%expect_test "duplicate argument name" =


### PR DESCRIPTION
Instead rely on exception handlers to print the errors. This fixes https://github.com/gridbugs/climate/issues/1.