### PR TITLE
Allow color in help messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Color in help messages (#6)
 - Improvements to formatting of help messages (#5)
 - Allow documentation for positional args (#4)
 - Improve filename completion (#3)

--- a/examples/fake_git.ml
+++ b/examples/fake_git.ml
@@ -30,7 +30,13 @@ let commit =
   let+ _amend = flag [ "amend" ] ~desc:"Amend a commit"
   and+ _all = flag [ "a" ] ~desc:"Commit all changes"
   and+ _branch = named_opt [ "b"; "branch" ] branch_conv
-  and+ _message = named_opt [ "m"; "message" ] string ~desc:"The commit message"
+  and+ _message =
+    named_opt
+      [ "m"; "message" ]
+      string
+      ~desc:
+        "The commit message. This description is extra long to exercise text wrapping in \
+         help messages."
   and+ _files = pos_all file ~desc:"The files to commit" in
   ()
 ;;

--- a/src/climate/ansi_style.ml
+++ b/src/climate/ansi_style.ml
@@ -1,0 +1,44 @@
+open Import
+
+module Color = struct
+  type t =
+    [ `Red
+    | `Green
+    | `Yellow
+    | `Blue
+    | `Magenta
+    | `Cyan
+    ]
+end
+
+type t =
+  { bold : bool
+  ; underline : bool
+  ; color : Color.t option
+  }
+
+let default = { bold = false; underline = false; color = None }
+let reset = "\x1b[0m"
+
+let escape { bold; underline; color } =
+  let effects =
+    List.append (if bold then [ ";1" ] else []) (if underline then [ ";4" ] else [])
+  in
+  let color_code =
+    match (color : Color.t option) with
+    | None -> 0
+    | Some `Red -> 31
+    | Some `Green -> 32
+    | Some `Yellow -> 33
+    | Some `Blue -> 34
+    | Some `Magenta -> 35
+    | Some `Cyan -> 36
+  in
+  Printf.sprintf "\x1b[%d%sm" color_code (String.concat ~sep:"" effects)
+;;
+
+let pp_with_style t ppf ~f =
+  Format.pp_print_string ppf (escape t);
+  f ppf;
+  Format.pp_print_string ppf reset
+;;

--- a/src/climate/ansi_style.mli
+++ b/src/climate/ansi_style.mli
@@ -1,0 +1,19 @@
+module Color : sig
+  type t =
+    [ `Red
+    | `Green
+    | `Yellow
+    | `Blue
+    | `Magenta
+    | `Cyan
+    ]
+end
+
+type t =
+  { bold : bool
+  ; underline : bool
+  ; color : Color.t option
+  }
+
+val default : t
+val pp_with_style : t -> Format.formatter -> f:(Format.formatter -> unit) -> unit

--- a/src/climate/climate.ml
+++ b/src/climate/climate.ml
@@ -588,7 +588,7 @@ module Arg_parser = struct
   ;;
 
   let pp_help ppf arg_spec command_line ~desc ~child_subcommands =
-    Help.pp ppf (help arg_spec command_line ~desc ~child_subcommands)
+    Help.pp Help.Style.default ppf (help arg_spec command_line ~desc ~child_subcommands)
   ;;
 
   let help_spec =

--- a/src/climate/help.mli
+++ b/src/climate/help.mli
@@ -1,5 +1,14 @@
 open Import
 
+module Style : sig
+  type t =
+    { name : Ansi_style.t
+    ; heading : Ansi_style.t
+    }
+
+  val default : t
+end
+
 type 'name entry =
   { name : 'name
   ; desc : string option
@@ -60,4 +69,4 @@ type t =
   ; sections : Sections.t
   }
 
-val pp : Format.formatter -> t -> unit
+val pp : Style.t -> Format.formatter -> t -> unit

--- a/tests/usage_tests/help_messages.ml
+++ b/tests/usage_tests/help_messages.ml
@@ -12,10 +12,10 @@ let%expect_test "empty spec" =
   run (unit_command ()) [ "--help" ];
   [%expect
     {|
-    Usage: foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
     |}]
 ;;
 
@@ -26,30 +26,28 @@ let%expect_test "subcommands" =
   run command [];
   [%expect
     {|
-    Usage: foo.exe [COMMAND]
-           foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [COMMAND]
+           foo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
 
-
-    Commands:
-      foo
-      bar
+    [33;1mCommands:[0m
+      [32;1mfoo [0m
+      [32;1mbar [0m
     |}];
   run command [ "--help" ];
   [%expect
     {|
-    Usage: foo.exe [COMMAND]
-           foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [COMMAND]
+           foo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
 
-
-    Commands:
-      foo
-      bar
+    [33;1mCommands:[0m
+      [32;1mfoo [0m
+      [32;1mbar [0m
     |}]
 ;;
 
@@ -66,32 +64,30 @@ let%expect_test "descriptions" =
     {|
     program description
 
-    Usage: foo.exe [COMMAND]
-           foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [COMMAND]
+           foo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
 
-
-    Commands:
-      foo  description of subcommand foo
-      bar  description of subcommand bar
+    [33;1mCommands:[0m
+      [32;1mfoo [0m description of subcommand foo
+      [32;1mbar [0m description of subcommand bar
     |}];
   run command [ "--help" ];
   [%expect
     {|
     program description
 
-    Usage: foo.exe [COMMAND]
-           foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [COMMAND]
+           foo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
 
-
-    Commands:
-      foo  description of subcommand foo
-      bar  description of subcommand bar
+    [33;1mCommands:[0m
+      [32;1mfoo [0m description of subcommand foo
+      [32;1mbar [0m description of subcommand bar
     |}];
   run command [ "foo" ];
   [%expect {||}];
@@ -100,10 +96,10 @@ let%expect_test "descriptions" =
     {|
     description of subcommand foo
 
-    Usage: foo.exe foo [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe foo [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
     |}]
 ;;
 
@@ -125,18 +121,17 @@ let%expect_test "arguments" =
   run command [ "--help" ];
   [%expect
     {|
-    Usage: foo.exe [OPTIONS] <XYZ> <ARG2>
+    [33;1mUsage: [0m[32;1mfoo.exe [OPTIONS] <XYZ> <ARG2>[0m
 
-    Arguments:
-      <XYZ>
-      <ARG2>  The second argument
+    [33;1mArguments:[0m
+      [32;1m<XYZ> [0m
+      [32;1m<ARG2> [0m The second argument
 
-
-    Options:
-      -f, --foo <FILE>  description of foo
-          --bar <ABC>   description of bar
-      -c <INT>
-      -h, --help        Print help
+    [33;1mOptions:[0m
+      [32;1m-f, --foo <FILE> [0m description of foo
+      [32;1m    --bar <ABC> [0m  description of bar
+      [32;1m-c <INT> [0m
+      [32;1m-h, --help [0m       Print help
     |}]
 ;;
 
@@ -170,54 +165,52 @@ let%expect_test "arguments and subcommands" =
     {|
     Fake version control software
 
-    Usage: foo.exe [COMMAND]
-           foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [COMMAND]
+           foo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
 
-
-    Commands:
-      log     List recent commits
-      commit  Make a new commit
+    [33;1mCommands:[0m
+      [32;1mlog [0m    List recent commits
+      [32;1mcommit [0m Make a new commit
     |}];
   run command [ "--help" ];
   [%expect
     {|
     Fake version control software
 
-    Usage: foo.exe [COMMAND]
-           foo.exe [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe [COMMAND]
+           foo.exe [OPTIONS][0m
 
-    Options:
-      -h, --help  Print help
+    [33;1mOptions:[0m
+      [32;1m-h, --help [0m Print help
 
-
-    Commands:
-      log     List recent commits
-      commit  Make a new commit
+    [33;1mCommands:[0m
+      [32;1mlog [0m    List recent commits
+      [32;1mcommit [0m Make a new commit
     |}];
   run command [ "log"; "--help" ];
   [%expect
     {|
     List recent commits
 
-    Usage: foo.exe log [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe log [OPTIONS][0m
 
-    Options:
-      -p, --pretty <VALUE>
-      -h, --help            Print help
+    [33;1mOptions:[0m
+      [32;1m-p, --pretty <VALUE> [0m
+      [32;1m-h, --help [0m           Print help
     |}];
   run command [ "commit"; "--help" ];
   [%expect
     {|
     Make a new commit
 
-    Usage: foo.exe commit [OPTIONS]
+    [33;1mUsage: [0m[32;1mfoo.exe commit [OPTIONS][0m
 
-    Options:
-      -a, --amend
-      -m, --message <STRING>
-      -h, --help              Print help
+    [33;1mOptions:[0m
+      [32;1m-a, --amend [0m
+      [32;1m-m, --message <STRING> [0m
+      [32;1m-h, --help [0m             Print help
     |}]
 ;;


### PR DESCRIPTION
For now all help messages will use the default color scheme copied from gleam. In a future change it will become possible to configure the colours.