### PR TITLE
Rename `desc` argument to `doc`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Rename `desc` in APIs to `doc` to avoid confusion with the `description` field of manpages. (#12)
+
 ## 0.4.0
 
 ### Added

--- a/examples/echo_ansi.ml
+++ b/examples/echo_ansi.ml
@@ -41,16 +41,16 @@ let main ~bold ~underline ~color words =
 
 let () =
   let command =
-    Command.singleton ~desc:"Echo with style!"
+    Command.singleton ~doc:"Echo with style!"
     @@
     let open Arg_parser in
-    (* Describe and parse the command line arguments:*)
-    let+ bold = flag [ "bold" ] ~desc:"Make the text bold"
-    and+ underline = flag [ "underline" ] ~desc:"Underline the text"
-    and+ color = named_opt [ "color" ] Color.conv ~desc:"Set the text color"
+    (* Describe and parse the command line arguments: *)
+    let+ bold = flag [ "bold" ] ~doc:"Make the text bold"
+    and+ underline = flag [ "underline" ] ~doc:"Underline the text"
+    and+ color = named_opt [ "color" ] Color.conv ~doc:"Set the text color"
     and+ words = pos_all string
     and+ completion =
-      flag [ "completion" ] ~desc:"Print this program's completion script and exit"
+      flag [ "completion" ] ~doc:"Print this program's completion script and exit"
     in
     if completion
     then `Completion
@@ -60,11 +60,11 @@ let () =
      that we should print the completion script. *)
   let help_style =
     let open Help_style in
-    { program_desc = { ansi_style_plain with color = Some `Green }
+    { program_doc = { ansi_style_plain with color = Some `Green }
     ; usage = { ansi_style_plain with color = Some `Yellow }
     ; section_heading = { ansi_style_plain with color = Some `Red }
     ; arg_name = { ansi_style_plain with color = Some `Blue }
-    ; arg_desc = { ansi_style_plain with color = Some `Cyan }
+    ; arg_doc = { ansi_style_plain with color = Some `Cyan }
     }
   in
   match

--- a/examples/fake_git.ml
+++ b/examples/fake_git.ml
@@ -27,17 +27,17 @@ let checkout =
 
 let commit =
   let open Arg_parser in
-  let+ _amend = flag [ "amend" ] ~desc:"Amend a commit"
-  and+ _all = flag [ "a" ] ~desc:"Commit all changes"
+  let+ _amend = flag [ "amend" ] ~doc:"Amend a commit"
+  and+ _all = flag [ "a" ] ~doc:"Commit all changes"
   and+ _branch = named_opt [ "b"; "branch" ] branch_conv
   and+ _message =
     named_opt
       [ "m"; "message" ]
       string
-      ~desc:
+      ~doc:
         "The commit message. This description is extra long to exercise text wrapping in \
          help messages."
-  and+ _files = pos_all file ~desc:"The files to commit" in
+  and+ _files = pos_all file ~doc:"The files to commit" in
   ()
 ;;
 
@@ -47,7 +47,7 @@ let log =
     named_opt
       [ "pretty"; "p" ]
       (string_enum [ "full"; "fuller"; "short"; "oneline" ])
-      ~desc:"foo"
+      ~doc:"foo"
   in
   ()
 ;;
@@ -65,18 +65,18 @@ let () =
   let open Command in
   group
     ~prose:(Manpage.prose ~description:[] ())
-    ~desc:"Fake version control"
-    [ subcommand "config" (singleton Arg_parser.unit ~desc:"Configure the tool.")
-    ; subcommand "checkout" (singleton checkout ~desc:"Check out a revision.")
-    ; subcommand "commit" (singleton commit ~desc:"Commit your changes.")
-    ; subcommand "log" (singleton log ~desc:"List recent commits.")
+    ~doc:"Fake version control"
+    [ subcommand "config" (singleton Arg_parser.unit ~doc:"Configure the tool.")
+    ; subcommand "checkout" (singleton checkout ~doc:"Check out a revision.")
+    ; subcommand "commit" (singleton commit ~doc:"Commit your changes.")
+    ; subcommand "log" (singleton log ~doc:"List recent commits.")
     ; subcommand
         "bisect"
         (group
            ~default_arg_parser:bisect_common
-           ~desc:"Binary search through previous commits."
-           [ subcommand "start" (singleton bisect_common ~desc:"Start a bisect.")
-           ; subcommand "reset" (singleton bisect_common ~desc:"Stop a bisect.")
+           ~doc:"Binary search through previous commits."
+           [ subcommand "start" (singleton bisect_common ~doc:"Start a bisect.")
+           ; subcommand "reset" (singleton bisect_common ~doc:"Stop a bisect.")
            ])
     ; subcommand ~hidden:true "__internal" print_completion_script_bash
     ]

--- a/examples/sum.ml
+++ b/examples/sum.ml
@@ -3,7 +3,7 @@ open Climate
 
 let main =
   let open Arg_parser in
-  let+ args = pos_all int ~desc:"The ints to be summed" in
+  let+ args = pos_all int ~doc:"The ints to be summed" in
   print_endline (Printf.sprintf "%d" (List.fold_left args ~init:0 ~f:( + )))
 ;;
 

--- a/examples/sum2.ml
+++ b/examples/sum2.ml
@@ -2,8 +2,8 @@ open Climate
 
 let main =
   let open Arg_parser in
-  let+ a = pos_req 0 int ~value_name:"LHS" ~desc:"The left hand side of the operation"
-  and+ b = pos_req 1 int ~value_name:"RHS" ~desc:"The right hand side of the operation" in
+  let+ a = pos_req 0 int ~value_name:"LHS" ~doc:"The left hand side of the operation"
+  and+ b = pos_req 1 int ~value_name:"RHS" ~doc:"The right hand side of the operation" in
   print_endline (Printf.sprintf "%d" (a + b))
 ;;
 

--- a/src/climate/climate.mli
+++ b/src/climate/climate.mli
@@ -28,10 +28,10 @@ module Help_style : sig
   val ansi_style_plain : ansi_style
 
   type t =
-    { program_desc : ansi_style
+    { program_doc : ansi_style
     ; usage : ansi_style
     ; arg_name : ansi_style
-    ; arg_desc : ansi_style
+    ; arg_doc : ansi_style
     ; section_heading : ansi_style
     }
 
@@ -188,7 +188,7 @@ module Arg_parser : sig
 
   (** A named argument that may appear multiple times on the command line. *)
   val named_multi
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?hidden:bool
     -> ?completion:'a Completion.t
@@ -198,7 +198,7 @@ module Arg_parser : sig
 
   (** A named argument that may appear at most once on the command line. *)
   val named_opt
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?hidden:bool
     -> ?completion:'a Completion.t
@@ -209,7 +209,7 @@ module Arg_parser : sig
   (** A named argument that may appear at most once on the command line. If the
       argument is not passed then a given default value will be used instead. *)
   val named_with_default
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?hidden:bool
     -> ?completion:'a Completion.t
@@ -220,7 +220,7 @@ module Arg_parser : sig
 
   (** A named argument that must appear exactly once on the command line. *)
   val named_req
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?hidden:bool
     -> ?completion:'a Completion.t
@@ -230,15 +230,15 @@ module Arg_parser : sig
 
   (** A flag that may appear multiple times on the command line.
       Evaluates to the number of times the flag appeared. *)
-  val flag_count : ?desc:string -> ?hidden:bool -> string list -> int t
+  val flag_count : ?doc:string -> ?hidden:bool -> string list -> int t
 
   (** A flag that may appear at most once on the command line. *)
-  val flag : ?desc:string -> string list -> bool t
+  val flag : ?doc:string -> string list -> bool t
 
   (** [pos_opt i conv] declares an optional anonymous positional
       argument at position [i] (starting at 0). *)
   val pos_opt
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?completion:'a Completion.t
     -> int
@@ -248,7 +248,7 @@ module Arg_parser : sig
   (** [pos_with_default i conv] declares an optional anonymous positional
       argument with a default value at position [i] (starting at 0). *)
   val pos_with_default
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?completion:'a Completion.t
     -> int
@@ -259,7 +259,7 @@ module Arg_parser : sig
   (** [pos_req i conv] declares a required anonymous positional
       argument at position [i] (starting at 0). *)
   val pos_req
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?completion:'a Completion.t
     -> int
@@ -268,7 +268,7 @@ module Arg_parser : sig
 
   (** Parses all positional arguments. *)
   val pos_all
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?completion:'a Completion.t
     -> 'a conv
@@ -277,7 +277,7 @@ module Arg_parser : sig
   (** [pos_left i conv] parses all positional arguments at positions less than
       i. *)
   val pos_left
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?completion:'a Completion.t
     -> int
@@ -287,7 +287,7 @@ module Arg_parser : sig
   (** [pos_right i conv] parses all positional arguments at positions greater
       than i. *)
   val pos_right
-    :  ?desc:string
+    :  ?doc:string
     -> ?value_name:string
     -> ?completion:'a Completion.t
     -> int
@@ -346,7 +346,7 @@ module Command : sig
   type 'a t
 
   (** Declare a single command. *)
-  val singleton : ?desc:string -> ?prose:Manpage.prose -> 'a Arg_parser.t -> 'a t
+  val singleton : ?doc:string -> ?prose:Manpage.prose -> 'a Arg_parser.t -> 'a t
 
   type 'a subcommand
 
@@ -359,7 +359,7 @@ module Command : sig
       passed with that argument. *)
   val group
     :  ?default_arg_parser:'a Arg_parser.t
-    -> ?desc:string
+    -> ?doc:string
     -> ?prose:Manpage.prose
     -> 'a subcommand list
     -> 'a t
@@ -439,7 +439,7 @@ module Command : sig
     -> ?program_name:Program_name.t
     -> ?help_style:Help_style.t
     -> ?version:string
-    -> ?desc:string
+    -> ?doc:string
     -> 'a Arg_parser.t
     -> 'a
 end

--- a/src/climate/help.mli
+++ b/src/climate/help.mli
@@ -2,10 +2,10 @@ open Import
 
 module Style : sig
   type t =
-    { program_desc : Ansi_style.t
+    { program_doc : Ansi_style.t
     ; usage : Ansi_style.t
     ; arg_name : Ansi_style.t
-    ; arg_desc : Ansi_style.t
+    ; arg_doc : Ansi_style.t
     ; section_heading : Ansi_style.t
     }
 
@@ -18,7 +18,7 @@ end
 
 type 'name entry =
   { name : 'name
-  ; desc : string option
+  ; doc : string option
   }
 
 module Value : sig
@@ -72,7 +72,7 @@ end
 type t =
   { program_name : string
   ; subcommand : string list
-  ; desc : string option
+  ; doc : string option
   ; sections : Sections.t
   }
 

--- a/src/climate/manpage.ml
+++ b/src/climate/manpage.ml
@@ -50,5 +50,5 @@ let to_troff_string { prose; help; version } =
        (Option.value version ~default:""))
     (String.capitalize_ascii help.program_name)
     command_name
-    (Option.map help.desc ~f:(sprintf " - %s") |> Option.value ~default:"")
+    (Option.map help.doc ~f:(sprintf " - %s") |> Option.value ~default:"")
 ;;

--- a/src/climate/spec.ml
+++ b/src/climate/spec.ml
@@ -12,7 +12,7 @@ module Named = struct
       ; default_string :
           string option (* default value to display in documentation (if any) *)
       ; required : bool (* determines if argument is shown in usage string *)
-      ; desc : string option
+      ; doc : string option
       ; completion : untyped_completion_hint option
       ; hidden : bool
       ; repeated : bool
@@ -24,12 +24,12 @@ module Named = struct
       | `Yes_with_value_name _ -> true
     ;;
 
-    let flag names ~desc ~hidden ~repeated =
+    let flag names ~doc ~hidden ~repeated =
       { names
       ; has_param = `No
       ; default_string = None
       ; required = false
-      ; desc
+      ; doc
       ; completion = None
       ; hidden
       ; repeated
@@ -53,7 +53,7 @@ module Named = struct
           | `Yes_with_value_name name -> Some { Help.Value.name; required = true }
         in
         let name = { Help.Named_args.names = t.names; value; repeated = t.repeated } in
-        Some { Help.name; desc = t.desc })
+        Some { Help.name; doc = t.doc })
     ;;
   end
 
@@ -103,7 +103,7 @@ module Positional = struct
     { required : bool
     ; value_name : string
     ; completion : untyped_completion_hint option
-    ; desc : string option
+    ; doc : string option
     }
 
   type all_above_inclusive =
@@ -123,11 +123,11 @@ module Positional = struct
     Option.is_none all_above_inclusive && Int.Map.is_empty others_by_index
   ;;
 
-  let help_entry_of_single_arg { required; value_name; desc; _ }
+  let help_entry_of_single_arg { required; value_name; doc; _ }
     : Help.Positional_args.entry
     =
     let name = { Help.Value.name = value_name; required } in
-    { Help.name; desc }
+    { Help.name; doc }
   ;;
 
   let help_entries { all_above_inclusive; others_by_index } =
@@ -167,10 +167,10 @@ module Positional = struct
       { t with others_by_index }
   ;;
 
-  let add_index t index ~value_name ~required ~completion ~desc =
+  let add_index t index ~value_name ~required ~completion ~doc =
     let others_by_index =
       Int.Map.update t.others_by_index ~key:index ~f:(function
-        | None -> Some { value_name; required; completion; desc }
+        | None -> Some { value_name; required; completion; doc }
         | Some x ->
           check_value_names index x.value_name value_name;
           if x.required <> required
@@ -180,7 +180,7 @@ module Positional = struct
     trim_map { t with others_by_index }
   ;;
 
-  let add_all_above_inclusive t index ~value_name ~completion ~desc =
+  let add_all_above_inclusive t index ~value_name ~completion ~doc =
     match t.all_above_inclusive with
     | Some x when x.index < index ->
       check_value_names index x.arg.value_name value_name;
@@ -189,13 +189,13 @@ module Positional = struct
       trim_map
         { t with
           all_above_inclusive =
-            Some { index; arg = { required = false; value_name; completion; desc } }
+            Some { index; arg = { required = false; value_name; completion; doc } }
         }
   ;;
 
-  let add_all_below_exclusive t index ~value_name ~required ~completion ~desc =
+  let add_all_below_exclusive t index ~value_name ~required ~completion ~doc =
     Seq.init index Fun.id
-    |> Seq.fold_left (add_index ~value_name ~required ~completion ~desc) t
+    |> Seq.fold_left (add_index ~value_name ~required ~completion ~doc) t
     |> trim_map
   ;;
 
@@ -295,8 +295,8 @@ let create_named info =
   { named; positional = Positional.empty }
 ;;
 
-let create_flag names ~desc ~hidden ~repeated =
-  create_named (Named.Info.flag names ~desc ~hidden ~repeated)
+let create_flag names ~doc ~hidden ~repeated =
+  create_named (Named.Info.flag names ~doc ~hidden ~repeated)
 ;;
 
 let help_sections { named; positional } =

--- a/src/climate/spec.mli
+++ b/src/climate/spec.mli
@@ -17,7 +17,7 @@ module Named : sig
       ; required : bool
       (** Just determines if argument is shown in
           usage string (not used for error checking) *)
-      ; desc : string option (** Description to display in help messages *)
+      ; doc : string option (** Description to display in help messages *)
       ; completion : untyped_completion_hint option
       (** Completion hint for this argument *)
       ; hidden : bool (** If true, then this argument doesn't show up
@@ -60,7 +60,7 @@ module Positional : sig
     -> value_name:string
     -> required:bool
     -> completion:untyped_completion_hint option
-    -> desc:string option
+    -> doc:string option
     -> t
 
   (** Create a spec with an unlimited number of positional arguments
@@ -70,7 +70,7 @@ module Positional : sig
     :  int
     -> value_name:string
     -> completion:untyped_completion_hint option
-    -> desc:string option
+    -> doc:string option
     -> t
 
   (** Create a spec with positional arguments from index 0 up to but
@@ -80,7 +80,7 @@ module Positional : sig
     -> value_name:string
     -> required:bool
     -> completion:untyped_completion_hint option
-    -> desc:string option
+    -> doc:string option
     -> t
 end
 
@@ -110,7 +110,7 @@ val create_named : Named.Info.t -> t
     doesn't take a value (ie. a flag). *)
 val create_flag
   :  Name.t Nonempty_list.t
-  -> desc:string option
+  -> doc:string option
   -> hidden:bool
   -> repeated:bool
   -> t

--- a/src/cmdliner/climate_cmdliner.ml
+++ b/src/cmdliner/climate_cmdliner.ml
@@ -97,7 +97,7 @@ module Cmd = struct
   let name (t : _ t) = t.name
 
   let v info term =
-    let command = Climate.Command.singleton ?desc:info.doc term in
+    let command = Climate.Command.singleton ?doc:info.doc term in
     { name = info.name; command }
   ;;
 
@@ -105,7 +105,7 @@ module Cmd = struct
     let command =
       Climate.Command.group
         ?default_arg_parser:default
-        ?desc:info.doc
+        ?doc:info.doc
         (List.map cmds ~f:(fun { name; command } ->
            Climate.Command.subcommand name command))
     in
@@ -147,7 +147,7 @@ module Arg = struct
   let conv_printer = snd
 
   type info =
-    { desc : string option
+    { doc : string option
     ; value_name : string option
     ; names : string list
     }
@@ -163,9 +163,7 @@ module Arg = struct
     | None -> failwith (Printf.sprintf "missing required argument")
   ;;
 
-  let info ?docs:_ignored ?docv ?doc ?env:_ names =
-    { desc = doc; value_name = docv; names }
-  ;;
+  let info ?docs:_ignored ?docv ?doc ?env:_ names = { doc; value_name = docv; names }
 
   let conv_to_climate (parse, print) =
     let parse string =
@@ -188,16 +186,16 @@ module Arg = struct
     parse, conv.print
   ;;
 
-  let opt conv default { desc; value_name; names } =
+  let opt conv default { doc; value_name; names } =
     Climate.Arg_parser.named_with_default
-      ?desc
+      ?doc
       ?value_name
       names
       (conv_to_climate conv)
       ~default
   ;;
 
-  let flag { desc; names; _ } = Climate.Arg_parser.flag ?desc names
+  let flag { doc; names; _ } = Climate.Arg_parser.flag ?doc names
 
   let some ?(none = "") (conv : 'a conv) : 'a option conv =
     let conv = conv_to_climate conv in
@@ -251,9 +249,9 @@ module Arg = struct
     Climate.Arg_parser.list ?sep (conv_to_climate conv) |> conv_of_climate
   ;;
 
-  let opt_all conv default { desc; names; value_name } =
+  let opt_all conv default { doc; names; value_name } =
     let open Climate.Arg_parser in
-    let+ values = named_multi ?desc ?value_name names (conv_to_climate conv) in
+    let+ values = named_multi ?doc ?value_name names (conv_to_climate conv) in
     match values with
     | [] -> default
     | xs -> xs

--- a/tests/usage_tests/help_messages.ml
+++ b/tests/usage_tests/help_messages.ml
@@ -8,7 +8,7 @@ let run command args =
   | Usage -> ()
 ;;
 
-let unit_command ?desc () = singleton ?desc Arg_parser.unit
+let unit_command ?doc () = singleton ?doc Arg_parser.unit
 
 let%expect_test "empty spec" =
   run (unit_command ()) [ "--help" ];
@@ -56,9 +56,9 @@ let%expect_test "subcommands" =
 let%expect_test "descriptions" =
   let command =
     group
-      ~desc:"program description"
-      [ subcommand "foo" (unit_command ~desc:"description of subcommand foo" ())
-      ; subcommand "bar" (unit_command ~desc:"description of subcommand bar" ())
+      ~doc:"program description"
+      [ subcommand "foo" (unit_command ~doc:"description of subcommand foo" ())
+      ; subcommand "bar" (unit_command ~doc:"description of subcommand bar" ())
       ]
   in
   run command [];
@@ -108,14 +108,14 @@ let%expect_test "descriptions" =
 let%expect_test "arguments" =
   let parser =
     let open Arg_parser in
-    let+ _ = named_opt [ "foo"; "f" ] ~desc:"description of foo" file
+    let+ _ = named_opt [ "foo"; "f" ] ~doc:"description of foo" file
     and+ _ =
       named_opt
         [ "bar" ]
-        ~desc:"description of bar"
+        ~doc:"description of bar"
         (string_enum ~default_value_name:"ABC" [ "a"; "b"; "c" ])
     and+ _ = named_opt [ "c" ] int
-    and+ _ = pos_req 1 string ~value_name:"ARG2" ~desc:"The second argument"
+    and+ _ = pos_req 1 string ~value_name:"ARG2" ~doc:"The second argument"
     and+ _ = pos_req 0 (string_enum [ "x"; "y"; "z" ]) ~value_name:"XYZ" in
     ()
   in
@@ -140,7 +140,7 @@ let%expect_test "arguments" =
 let%expect_test "arguments and subcommands" =
   let log =
     singleton
-      ~desc:"List recent commits"
+      ~doc:"List recent commits"
       (let open Arg_parser in
        let+ _pretty =
          named_opt
@@ -151,7 +151,7 @@ let%expect_test "arguments and subcommands" =
   in
   let commit =
     singleton
-      ~desc:"Make a new commit"
+      ~doc:"Make a new commit"
       (let open Arg_parser in
        let+ _amend = flag [ "amend"; "a" ]
        and+ _message = named_opt [ "m"; "message" ] string in
@@ -159,7 +159,7 @@ let%expect_test "arguments and subcommands" =
   in
   let command =
     group
-      ~desc:"Fake version control software"
+      ~doc:"Fake version control software"
       [ subcommand "log" log; subcommand "commit" commit ]
   in
   run command [];


### PR DESCRIPTION
This is to avoid confusion with the `description` field of manpages.