### PR TITLE
Quote some values in error messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Quote some values in error messages (#24)
+
 ## 0.8.4
 
 ### Changed

--- a/src/climate/error.ml
+++ b/src/climate/error.ml
@@ -93,12 +93,12 @@ module Parse_error = struct
        | None -> sprintf "Failed to parse the argument: %s" message)
     | Too_many_positional_arguments { max = 0; first_excess_argument } ->
       sprintf
-        "This command does not accept any positional arguments. First excess argument: %s"
+        "This command does not accept any positional arguments. First excess argument: %S"
         first_excess_argument
     | Too_many_positional_arguments { max; first_excess_argument } ->
       sprintf
         "Too many positional arguments. At most %d positional arguments may be passed. \
-         First excess argument: %s"
+         First excess argument: %S"
         max
         first_excess_argument
     | Invalid_char_in_argument_name { attempted_argument_name; invalid_char } ->
@@ -106,7 +106,7 @@ module Parse_error = struct
         "Invalid character %C in argument name %S"
         invalid_char
         attempted_argument_name
-    | No_such_subcommand subcommand -> sprintf "No such subcommand: %s" subcommand
+    | No_such_subcommand subcommand -> sprintf "No such subcommand: %S" subcommand
   ;;
 
   let exit_code = 124

--- a/tests/unit_tests/parse_error_tests.ml
+++ b/tests/unit_tests/parse_error_tests.ml
@@ -9,14 +9,20 @@ let%expect_test "no args to empty parser" =
 let%expect_test "positional args passed to command with no positional args" =
   run (Command.singleton (Arg_parser.const ())) [ "foo"; "bar"; "baz" ];
   [%expect
-    {| This command does not accept any positional arguments. First excess argument: foo |}]
+    {| This command does not accept any positional arguments. First excess argument: "foo" |}]
+;;
+
+let%expect_test "empty string passed to command with no positional args" =
+  run (Command.singleton (Arg_parser.const ())) [ "" ];
+  [%expect
+    {| This command does not accept any positional arguments. First excess argument: "" |}]
 ;;
 
 let%expect_test "positional args passed to command with no positional args" =
   let term = Arg_parser.(pos_req 0 string) in
   run (Command.singleton term) [ "foo"; "bar"; "baz" ];
   [%expect
-    {| Too many positional arguments. At most 1 positional arguments may be passed. First excess argument: bar |}]
+    {| Too many positional arguments. At most 1 positional arguments may be passed. First excess argument: "bar" |}]
 ;;
 
 let%expect_test "unknown argument name" =
@@ -119,5 +125,5 @@ let%expect_test "no such subcommand" =
     group [ subcommand "foo" (group [ subcommand "bar" (singleton term) ]) ]
   in
   run command [ "foo"; "baz" ];
-  [%expect {| No such subcommand: baz |}]
+  [%expect {| No such subcommand: "baz" |}]
 ;;


### PR DESCRIPTION
This helps to understand the errors about invalid arguments when the argument's value is the empty string.