### PR TITLE
feat: hidden option for arg_parser.flag

### DIFF
--- a/src/climate/arg_parser.ml
+++ b/src/climate/arg_parser.ml
@@ -559,8 +559,8 @@ let flag_count ?doc ?hidden names =
       Ok (Raw_arg_table.get_flag_count_names context.raw_arg_table names))
 ;;
 
-let flag_gen ?doc names ~allow_many =
-  flag_count ?doc names
+let flag_gen ?doc ?hidden names ~allow_many =
+  flag_count ?doc ?hidden names
   |> map_context' ~f:(fun n context ->
     match n with
     | 0 -> Ok false

--- a/src/climate/arg_parser.mli
+++ b/src/climate/arg_parser.mli
@@ -173,7 +173,7 @@ val named_req
 val flag_count : ?doc:string -> ?hidden:bool -> string list -> int t
 
 (** A flag that may appear at most once on the command line. *)
-val flag : ?doc:string -> string list -> bool t
+val flag : ?doc:string -> ?hidden:bool -> string list -> bool t
 
 (** [pos_opt i conv] declares an optional anonymous positional
     argument at position [i] (starting at 0). *)


### PR DESCRIPTION
This pull request allows arguments received via `flag` in arg_parser.ml to be hidden, similar to `flag_count`.

Since the changes are minor, if you plan to accept the changes but do not wish to add me as a contributor, you may close the pull request and make the changes yourself.